### PR TITLE
Support npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "bats-core",
+  "version": "0.1.0",
+  "private": true
+}


### PR DESCRIPTION
This is a minimal package.json.

`name` and `version` are required by npm to install.

`private` is not required, but is to prevent this module from accidentally being published to npm until/if desired. (I think it's advisable to leverage github for now.)

Of course, there is a lot of other metadata that would be useful in the package:
`description`, `homepage`, `repository`, `bugs`, `license`

However, since bpkg also uses package.json ([currently, anyway](https://github.com/bpkg/bpkg/issues/17)), I added only the bare minimum properties at the moment.

I'm waiting to open a similar PR to bats-assert until any issues are discussed here, (since the bats-assert package.json will be virtually the same). The only difference is that the bats-assert package.json will include bats-core as a dependency (direct or peer, TBD)
