### PR TITLE
Add other relevant metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,20 @@
 {
   "name": "bats-core",
   "version": "0.1.0",
-  "private": true
+  "private": true,
+  "description": "Supporting library for Bats test helpers",
+  "homepage": "https://github.com/ztombol/bats-core#readme",
+  "license": "CC0-1.0",
+  "author": "Zoltán Tömböl",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/ztombol/bats-core.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ztombol/bats-core/issues"
+  },
+  "directories": {
+    "lib": "src",
+    "test": "test"
+  }
 }


### PR DESCRIPTION
I'm not sure how much, if any, of this extra metadata you care to include. I kept it separate from the original npm PR so that the optional fields could be discussed individually.

These are the most common fields. In fact, these are autogenerated using `npm init`. I'm not sure whether we would care to include them or not. I think it would definitely be nice to include the `license` field. But `bugs`, `repository` and `homepage` all just point back to github, which is redundant so long as this isn't published to the npm registry. (As are the `keywords` and `description`)

Do you have an opinion either way?
